### PR TITLE
Updated imports to include ggplot2::Stat to address issue #14

### DIFF
--- a/R/geom-edges.R
+++ b/R/geom-edges.R
@@ -288,7 +288,7 @@ geom_edgelabel_repel <- geom_edgetext_repel
 #' @importFrom ggplot2 ggproto
 #' @keywords internal
 StatEdges <-
-  ggplot2::ggproto("StatEdges", Stat,
+  ggplot2::ggproto("StatEdges", ggplot2::Stat,
                    compute_layer = function(data, scales, params) {
                      unique(subset(data, !(x == xend & y == yend)))
                    }
@@ -297,7 +297,7 @@ StatEdges <-
 #' @importFrom ggplot2 ggproto
 #' @keywords internal
 StatMidEdges <-
-  ggplot2::ggproto("StatMidEdges", Stat,
+  ggplot2::ggproto("StatMidEdges", ggplot2::Stat,
                    compute_layer = function(data, scales, params) {
                      data = subset(data, !(x == xend & y == yend))
                      data$x = (data$x + data$xend) / 2

--- a/R/geom-nodes.R
+++ b/R/geom-nodes.R
@@ -368,7 +368,7 @@ geom_nodelabel_repel <- function(
 #' @importFrom ggplot2 ggproto
 #' @keywords internal
 StatNodes <-
-  ggplot2::ggproto("StatNodes", Stat,
+  ggplot2::ggproto("StatNodes", ggplot2::Stat,
                    compute_layer = function(data, scales, params) {
                      if (all(c("xend", "yend") %in% names(data))) {
                        unique(subset(data, select = c(-xend, -yend)))

--- a/man/geom_edges.Rd
+++ b/man/geom_edges.Rd
@@ -31,7 +31,7 @@ plot. You must supply \code{mapping} if there is no plot mapping.}
 \item{position}{Position adjustment, either as a string, or the result of
 a call to a position adjustment function.}
 
-\item{arrow}{specification for arrow heads, as created by arrow()}
+\item{arrow}{specification for arrow heads, as created by arrow().}
 
 \item{curvature}{A numeric value giving the amount of curvature.
     Negative values produce left-hand curves, positive values
@@ -46,8 +46,8 @@ a call to a position adjustment function.}
 \item{ncp}{The number of control points used to draw the curve.
     More control points creates a smoother curve.}
 
-\item{na.rm}{If \code{FALSE} (the default), removes missing values with
-a warning.  If \code{TRUE} silently removes missing values.}
+\item{na.rm}{If \code{FALSE}, the default, missing values are removed with
+a warning. If \code{TRUE}, missing values are silently removed.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.

--- a/man/geom_edgetext.Rd
+++ b/man/geom_edgetext.Rd
@@ -57,8 +57,8 @@ Useful for offsetting text from points, particularly on discrete scales.}
 
 \item{label.size}{Size of label border, in mm.}
 
-\item{na.rm}{If \code{FALSE} (the default), removes missing values with
-a warning.  If \code{TRUE} silently removes missing values.}
+\item{na.rm}{If \code{FALSE}, the default, missing values are removed with
+a warning. If \code{TRUE}, missing values are silently removed.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.

--- a/man/geom_edgetext_repel.Rd
+++ b/man/geom_edgetext_repel.Rd
@@ -37,7 +37,7 @@ displayed as described in ?plotmath}
 
   \itemize{
     \item Aesthetics: to set an aesthetic to a fixed value, like
-       \code{color = "red"} or \code{size = 3}.
+       \code{colour = "red"} or \code{size = 3}.
     \item Other arguments to the layer, for example you override the
       default \code{stat} associated with the layer.
     \item Other arguments passed on to the stat.
@@ -55,10 +55,8 @@ displayed as described in ?plotmath}
 
 \item{label.size}{Size of label border, in mm.}
 
-\item{segment.color}{Color of the line segment connecting the data point to
-the text labe. Defaults to \code{#666666}.}
-
-\item{segment.size}{Width of segment, in mm.}
+\item{segment.size}{Width of line segment connecting the data point to
+the text label, in mm.}
 
 \item{arrow}{specification for arrow heads, as created by \code{\link[grid]{arrow}}}
 

--- a/man/geom_nodes.Rd
+++ b/man/geom_nodes.Rd
@@ -30,8 +30,8 @@ plot. You must supply \code{mapping} if there is no plot mapping.}
 \item{position}{Position adjustment, either as a string, or the result of
 a call to a position adjustment function.}
 
-\item{na.rm}{If \code{FALSE} (the default), removes missing values with
-a warning.  If \code{TRUE} silently removes missing values.}
+\item{na.rm}{If \code{FALSE}, the default, missing values are removed with
+a warning. If \code{TRUE}, missing values are silently removed.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.

--- a/man/geom_nodetext.Rd
+++ b/man/geom_nodetext.Rd
@@ -49,10 +49,10 @@ displayed as described in ?plotmath}
 Useful for offsetting text from points, particularly on discrete scales.}
 
 \item{check_overlap}{If \code{TRUE}, text that overlaps previous text in the
-same layer will not be plotted. A quick and dirty way}
+same layer will not be plotted.}
 
-\item{na.rm}{If \code{FALSE} (the default), removes missing values with
-a warning.  If \code{TRUE} silently removes missing values.}
+\item{na.rm}{If \code{FALSE}, the default, missing values are removed with
+a warning. If \code{TRUE}, missing values are silently removed.}
 
 \item{show.legend}{logical. Should this layer be included in the legends?
 \code{NA}, the default, includes if any aesthetics are mapped.

--- a/man/geom_nodetext_repel.Rd
+++ b/man/geom_nodetext_repel.Rd
@@ -36,7 +36,7 @@ displayed as described in ?plotmath}
 
   \itemize{
     \item Aesthetics: to set an aesthetic to a fixed value, like
-       \code{color = "red"} or \code{size = 3}.
+       \code{colour = "red"} or \code{size = 3}.
     \item Other arguments to the layer, for example you override the
       default \code{stat} associated with the layer.
     \item Other arguments passed on to the stat.
@@ -48,10 +48,8 @@ displayed as described in ?plotmath}
 \item{point.padding}{Amount of padding around labeled point. Defaults to
 \code{unit(0, "lines")}.}
 
-\item{segment.color}{Color of the line segment connecting the data point to
-the text labe. Defaults to \code{#666666}.}
-
-\item{segment.size}{Width of segment, in mm.}
+\item{segment.size}{Width of line segment connecting the data point to
+the text label, in mm.}
 
 \item{arrow}{specification for arrow heads, as created by \code{\link[grid]{arrow}}}
 


### PR DESCRIPTION
Hope this is helpful...

Added the import of ggplot2::Stat as discussed in issue #14.  Appears to have done the trick.  Package version needs bumped.  Build still has unrelated warnings/notes in tests.  Specifically:

```
* checking Rd \usage sections ... WARNING
Undocumented arguments in documentation object 'geom_edgetext_repel'
  'segment.color'

Undocumented arguments in documentation object 'geom_nodetext_repel'
  'segment.color'

Functions with \usage entries need to have the appropriate \alias
entries, and all their arguments documented.
The \usage entries must correspond to syntactically valid R code.
See chapter 'Writing R documentation files' in the 'Writing R
Extensions' manual.
```

and in tests:

```
* checking tests ...
  Running 'testthat.R' ERROR
Running the tests in 'tests/testthat.R' failed.
Last 13 lines of output:
   Type help(package="sna") to get started.
  
  1. Failure: load_pkg works (@test-utilities.R#5) -------------------------------
  error$message does not match "install the".
  Actual value: "could not find function "load_pkg""
  
  
  testthat results ================================================================
  OK: 14 SKIPPED: 0 FAILED: 1
  1. Failure: load_pkg works (@test-utilities.R#5) 
  
  Error: testthat unit tests failed
  Execution halted
```