### PR TITLE
Error when only one edge found

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,8 @@
 
 S3method(fortify,igraph)
 S3method(fortify,network)
+S3method(ggnetwork,default)
+S3method(ggnetwork,igraph)
 export(geom_edgelabel)
 export(geom_edgelabel_repel)
 export(geom_edges)

--- a/R/fortify-network.R
+++ b/R/fortify-network.R
@@ -139,7 +139,7 @@ fortify.network <- function(model, data = NULL,
   edges = network::as.matrix.network.edgelist(x, attrname = weights)
 
   # edge list (if there are duplicated rows)
-  if (nrow(edges[, 1:2]) > nrow(unique(edges[, 1:2]))) {
+  if (nrow(edges[, 1:2, drop = FALSE]) > nrow(unique(edges[, 1:2, drop = FALSE]))) {
     warning("duplicated edges detected")
   }
 

--- a/R/geom-edges.R
+++ b/R/geom-edges.R
@@ -197,6 +197,7 @@ geom_edgetext <- function(mapping = NULL, data = NULL,
 #' @inheritParams ggrepel::geom_label_repel
 #' @param nudge_x,nudge_y Horizontal and vertical adjustments to nudge the
 #'   starting position of each text label.
+#' @param segment.color Color of the line segment. 
 #' @importFrom ggplot2 layer
 #' @importFrom ggrepel GeomLabelRepel
 #' @examples

--- a/R/geom-nodes.R
+++ b/R/geom-nodes.R
@@ -148,6 +148,7 @@ geom_nodetext <- function(mapping = NULL,
 #' @inheritParams ggrepel::geom_text_repel
 #' @param nudge_x,nudge_y Horizontal and vertical adjustments to nudge the
 #'   starting position of each text label.
+#' @param segment.color Color of the line segment.
 #' @importFrom ggplot2 layer
 #' @importFrom ggrepel GeomTextRepel
 #' @examples

--- a/R/ggnetwork.R
+++ b/R/ggnetwork.R
@@ -12,31 +12,34 @@
 #' it will be used to convert the object: see
 #' \code{\link{fortify.igraph}} for details.
 #' @param ... arguments passed to the \code{\link{fortify.network}} function.
+#' @rdname ggnetwork
 #' @export
 ggnetwork <- function(x, ...) {
+    UseMethod('ggnetwork')
+}
 
-  if (class(x) == "igraph") {
+#' @export
+#' @rdname ggnetwork
+#' @method ggnetwork igraph
+ggnetwork.igraph <- function(x, ...) {
 
     fortify.igraph(x, ...)
 
-  } else {
+} 
+
+#' @export
+#' @rdname ggnetwork
+#' @method ggnetwork default
+ggnetwork.default <- function(x, ...) {
 
     if (!network::is.network(x)) {
-
-      x = try(network::network(x), silent = TRUE)
-
+        x <- try(network::network(x), silent = TRUE)
     }
 
-    if (!network::is.network(x)) {
+    if (!network::is.network(x)) stop("could not coerce object to a network")
 
-      stop("could not coerce object to a network")
-
-    } else {
-
-      fortify.network(x, ...)
-
-    }
-
-  }
+    fortify.network(x, ...)
 
 }
+
+

--- a/man/geom_edgetext_repel.Rd
+++ b/man/geom_edgetext_repel.Rd
@@ -55,6 +55,8 @@ displayed as described in ?plotmath}
 
 \item{label.size}{Size of label border, in mm.}
 
+\item{segment.color}{Color of the line segment.}
+
 \item{segment.size}{Width of line segment connecting the data point to
 the text label, in mm.}
 

--- a/man/geom_nodetext_repel.Rd
+++ b/man/geom_nodetext_repel.Rd
@@ -48,6 +48,8 @@ displayed as described in ?plotmath}
 \item{point.padding}{Amount of padding around labeled point. Defaults to
 \code{unit(0, "lines")}.}
 
+\item{segment.color}{Color of the line segment.}
+
 \item{segment.size}{Width of line segment connecting the data point to
 the text label, in mm.}
 

--- a/man/ggnetwork.Rd
+++ b/man/ggnetwork.Rd
@@ -2,9 +2,15 @@
 % Please edit documentation in R/ggnetwork.R
 \name{ggnetwork}
 \alias{ggnetwork}
+\alias{ggnetwork.default}
+\alias{ggnetwork.igraph}
 \title{Fortify network objects.}
 \usage{
 ggnetwork(x, ...)
+
+\method{ggnetwork}{igraph}(x, ...)
+
+\method{ggnetwork}{default}(x, ...)
 }
 \arguments{
 \item{x}{an object of class \code{\link[network]{network}}, or any object


### PR DESCRIPTION
Added `, drop = FALSE` to line 142 of file fortify-network.R:

```
nrow(edges[, 1:2, drop = FALSE]) > nrow(unique(edges[, 1:2, drop = FALSE]))
```

This prevents the matrix turning into a vector in the edge case when only a single edge is found.

For example, this failed previously but will work now:
```
library(igraph)
library(ggnetwork)

mat <- structure(c(0, 0, 0, 0.0930232558139535, 0, 0, 0, 0, 0, 0, 0, 
1, 0.0930232558139535, 0, 1, 0), .Dim = c(4L, 4L), .Dimnames = list(
    c("response_cries", "back_channels", "summons", "justification"
    ), c("response_cries", "back_channels", "summons", "justification"
    )))

graph <- igraph::graph.adjacency(mat, weighted=TRUE, mode="lower")
igraph::E(graph)$width  <- igraph::E(graph)$weight * 5
net <- igraph::as.undirected(igraph::delete.edges(graph, igraph::E(graph)[weight < .1]))
plot(net)
idat <- try(ggnetwork::ggnetwork(net), TRUE)
idat
```