### PR TITLE
Fixing "color" inconsistency ("ggrepel") and error for nodes=2

### DIFF
--- a/R/fortify-network.R
+++ b/R/fortify-network.R
@@ -102,7 +102,7 @@ if (getRversion() >= "2.15.1") {
 #' @export
 fortify.network <- function(model, data = NULL,
                             layout = "fruchtermanreingold", weights = NULL,
-                            arrow.gap = ifelse(network::is.directed(x), 0.025, 0),
+                            arrow.gap = ifelse(network::is.directed(model), 0.025, 0),
                             by = NULL,
                             ...) {
   x = model
@@ -139,7 +139,7 @@ fortify.network <- function(model, data = NULL,
   edges = network::as.matrix.network.edgelist(x, attrname = weights)
 
   # edge list (if there are duplicated rows)
-  if (nrow(edges[, 1:2]) > nrow(unique(edges[, 1:2]))) {
+  if (nrow(edges[, 1:2, drop = FALSE]) > nrow(unique(edges[, 1:2, drop = FALSE]))) {
     warning("duplicated edges detected")
   }
 

--- a/R/fortify-network.R
+++ b/R/fortify-network.R
@@ -166,10 +166,10 @@ fortify.network <- function(model, data = NULL,
     names(edges)[ncol(edges)] = y
   }
 
-  # merge edges and nodes data
-  edges = merge(nodes, edges, by = c("x", "y"), all = TRUE)
-
   if (nrow(edges)!=0) {
+    # merge edges and nodes data
+    edges = merge(nodes, edges, by = c("x", "y"), all = TRUE)
+    
     # add missing columns to nodes data
     nodes$xend = nodes$x
     nodes$yend = nodes$y
@@ -199,7 +199,6 @@ fortify.network <- function(model, data = NULL,
     # add missing columns to nodes data
     nodes$xend = nodes$x
     nodes$yend = nodes$y
-    names(nodes) = names(edges)[1:ncol(nodes)]
     return(nodes)
   }
 

--- a/R/geom-edges.R
+++ b/R/geom-edges.R
@@ -18,27 +18,27 @@
 #'
 #' # just edges
 #' ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-#'   geom_edges(size = 1, color = "steelblue") +
+#'   geom_edges(size = 1, colour = "steelblue") +
 #'   theme_blank()
 #'
 #' # with nodes
 #' ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-#'   geom_edges(size = 1, color = "steelblue") +
-#'   geom_nodes(size = 3, color = "steelblue") +
+#'   geom_edges(size = 1, colour = "steelblue") +
+#'   geom_nodes(size = 3, colour = "steelblue") +
 #'   theme_blank()
 #'
 #' # with arrows
 #' ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-#'   geom_edges(size = 1, color = "steelblue",
+#'   geom_edges(size = 1, colour = "steelblue",
 #'              arrow = arrow(length = unit(0.5, "lines"), type = "closed")) +
-#'   geom_nodes(size = 3, color = "steelblue") +
+#'   geom_nodes(size = 3, colour = "steelblue") +
 #'   theme_blank()
 #'
 #' # with curvature
 #' ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-#'   geom_edges(size = 1, color = "steelblue", curvature = 0.15,
+#'   geom_edges(size = 1, colour = "steelblue", curvature = 0.15,
 #'              arrow = arrow(length = unit(0.5, "lines"), type = "closed")) +
-#'   geom_nodes(size = 3, color = "steelblue") +
+#'   geom_nodes(size = 3, colour = "steelblue") +
 #'   theme_blank()
 #'
 #' # arbitrary categorical edge attribute
@@ -47,25 +47,25 @@
 #' ggplot(n, aes(x, y, xend = xend, yend = yend)) +
 #'   geom_edges(aes(linetype = type), size = 1, curvature = 0.15,
 #'              arrow = arrow(length = unit(0.5, "lines"), type = "closed")) +
-#'   geom_nodes(size = 3, color = "steelblue") +
+#'   geom_nodes(size = 3, colour = "steelblue") +
 #'   theme_blank()
 #'
 #' # arbitrary numeric edge attribute (signed network)
 #' e <- sample(-2:2, network.edgecount(n), replace = TRUE)
 #' set.edge.attribute(n, "weight", e)
 #' ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-#'   geom_edges(aes(color = weight), curvature = 0.15,
+#'   geom_edges(aes(colour = weight), curvature = 0.15,
 #'              arrow = arrow(length = unit(0.5, "lines"), type = "closed")) +
-#'   geom_nodes(size = 3, color = "grey50") +
-#'   scale_color_gradient(low = "steelblue", high = "tomato") +
+#'   geom_nodes(size = 3, colour = "grey50") +
+#'   scale_colour_gradient(low = "steelblue", high = "tomato") +
 #'   theme_blank()
 #'
 #' # draw only a subset of all edges
 #' positive_weight <- function(x) { x[ x$weight >= 0, ] }
 #' ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-#'   geom_edges(aes(color = weight), data = positive_weight) +
-#'   geom_nodes(size = 4, color = "grey50") +
-#'   scale_color_gradient(low = "gold", high = "tomato") +
+#'   geom_edges(aes(colour = weight), data = positive_weight) +
+#'   geom_nodes(size = 4, colour = "grey50") +
+#'   scale_colour_gradient(low = "gold", high = "tomato") +
 #'   theme_blank()
 #'
 #' }
@@ -136,9 +136,9 @@ geom_edges <- function(mapping = NULL, data = NULL,
 #'
 #' # with labelled edges
 #' ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-#'   geom_edges(aes(color = type)) +
-#'   geom_edgetext(aes(label = type, color = type)) +
-#'   geom_nodes(size = 4, color = "grey50") +
+#'   geom_edges(aes(colour = type)) +
+#'   geom_edgetext(aes(label = type, colour = type)) +
+#'   geom_nodes(size = 4, colour = "grey50") +
 #'   theme_blank()
 #'
 #' # label only a subset of all edges with arbitrary symbol
@@ -146,7 +146,7 @@ geom_edges <- function(mapping = NULL, data = NULL,
 #' ggplot(n, aes(x, y, xend = xend, yend = yend)) +
 #'   geom_edges() +
 #'   geom_edgetext(label = "=", data = edge_type) +
-#'   geom_nodes(size = 4, color = "grey50") +
+#'   geom_nodes(size = 4, colour = "grey50") +
 #'   theme_blank()
 #'
 #' }
@@ -213,17 +213,17 @@ geom_edgetext <- function(mapping = NULL, data = NULL,
 #' ggplot(n, aes(x, y, xend = xend, yend = yend)) +
 #'   geom_edges() +
 #'   geom_edgetext_repel(aes(label = day), box.padding = unit(0.5, "lines")) +
-#'   geom_nodes(size = 4, color = "grey50") +
+#'   geom_nodes(size = 4, colour = "grey50") +
 #'   theme_blank()
 #'
 #' # repulsive edge labels for only a subset of all edges
 #' edge_day <- function(x) { x[ x$day > 2, ] }
 #' ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-#'   geom_edges(aes(color = cut(day, (4:0)[ -3 ]))) +
+#'   geom_edges(aes(colour = cut(day, (4:0)[ -3 ]))) +
 #'   geom_edgetext_repel(aes(label = paste("day", day),
-#'                       color = cut(day, (4:0)[ -3 ])), data = edge_day) +
-#'   geom_nodes(size = 4, color = "grey50") +
-#'   scale_color_manual("day", labels = c("old ties", "day 3", "day 4"),
+#'                       colour = cut(day, (4:0)[ -3 ])), data = edge_day) +
+#'   geom_nodes(size = 4, colour = "grey50") +
+#'   scale_colour_manual("day", labels = c("old ties", "day 3", "day 4"),
 #'                      values = c("grey50", "gold", "tomato")) +
 #'   theme_blank()
 #'
@@ -238,7 +238,7 @@ geom_edgetext_repel <- function(
   point.padding = unit(1e-6, "lines"),
   label.r = unit(0.15, "lines"),
   label.size = 0.25,
-  segment.color = "#666666",
+  segment.colour = "#666666",
   segment.size = 0.5,
   arrow = NULL,
   force = 1,
@@ -264,7 +264,7 @@ geom_edgetext_repel <- function(
       point.padding  = point.padding,
       label.r = label.r,
       label.size = label.size,
-      segment.color = segment.color,
+      segment.colour = segment.colour,
       segment.size = segment.size,
       arrow = arrow,
       na.rm = na.rm,

--- a/R/geom-nodes.R
+++ b/R/geom-nodes.R
@@ -12,28 +12,28 @@
 #'
 #' # just nodes
 #' ggplot(n, aes(x, y)) +
-#'   geom_nodes(size = 3, shape = 21, color = "steelblue") +
+#'   geom_nodes(size = 3, shape = 21, colour = "steelblue") +
 #'   theme_blank()
 #'
 #' # with edges
 #' ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-#'   geom_edges(color = "steelblue") +
-#'   geom_nodes(size = 3, shape = 21, color = "steelblue", fill = "white") +
+#'   geom_edges(colour = "steelblue") +
+#'   geom_nodes(size = 3, shape = 21, colour = "steelblue", fill = "white") +
 #'   theme_blank()
 #'
 #' # with nodes sized according to degree centrality
 #' ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-#'   geom_edges(color = "steelblue") +
-#'   geom_nodes(size = degree(n), shape = 21, color = "steelblue", fill = "white") +
+#'   geom_edges(colour = "steelblue") +
+#'   geom_nodes(size = degree(n), shape = 21, colour = "steelblue", fill = "white") +
 #'   theme_blank()
 #'
 #' # with nodes colored according to betweenness centrality
 #'
 #' n %v% "betweenness" <- betweenness(flo)
 #' ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-#'   geom_edges(color = "grey50") +
-#'   geom_nodes(aes(color = betweenness), size = 3) +
-#'   scale_color_gradient(low = "gold", high = "tomato") +
+#'   geom_edges(colour = "grey50") +
+#'   geom_nodes(aes(colour = betweenness), size = 3) +
+#'   scale_colour_gradient(low = "gold", high = "tomato") +
 #'   theme_blank() +
 #'   theme(legend.position = "bottom")
 #'
@@ -85,14 +85,14 @@ geom_nodes <- function(mapping = NULL, data = NULL,
 #'
 #' # with nodes underneath
 #' ggplot(n, aes(x, y)) +
-#'   geom_nodes(color = "gold", size = 9) +
+#'   geom_nodes(colour = "gold", size = 9) +
 #'   geom_nodetext(aes(label = vertex.names)) +
 #'   theme_blank()
 #'
 #' # with nodes and edges
 #' ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-#'   geom_edges(color = "gold") +
-#'   geom_nodes(color = "gold", size = 9) +
+#'   geom_edges(colour = "gold") +
+#'   geom_nodes(colour = "gold", size = 9) +
 #'   geom_nodetext(aes(label = vertex.names)) +
 #'   theme_blank()
 #'
@@ -157,10 +157,10 @@ geom_nodetext <- function(mapping = NULL,
 #'
 #' n <- network(rgraph(10, tprob = 0.2), directed = FALSE)
 #' ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-#'   geom_edges(color = "steelblue") +
+#'   geom_edges(colour = "steelblue") +
 #'   geom_nodetext_repel(aes(label = paste("node", vertex.names)),
 #'                       box.padding = unit(1, "lines")) +
-#'   geom_nodes(color = "steelblue", size = 3) +
+#'   geom_nodes(colour = "steelblue", size = 3) +
 #'   theme_blank()
 #'
 #' }
@@ -172,7 +172,7 @@ geom_nodetext_repel <- function(mapping = NULL,
                                 ...,
                                 box.padding = unit(0.25, "lines"),
                                 point.padding = unit(1e-06, "lines"),
-                                segment.color = "#666666",
+                                segment.colour = "#666666",
                                 segment.size = 0.5,
                                 arrow = NULL,
                                 force = 1,
@@ -194,7 +194,7 @@ geom_nodetext_repel <- function(mapping = NULL,
           na.rm = na.rm,
           box.padding = box.padding,
           point.padding = point.padding,
-          segment.color = segment.color,
+          segment.colour = segment.colour,
           segment.size = segment.size,
           arrow = arrow,
           force = force,
@@ -221,14 +221,14 @@ geom_nodetext_repel <- function(mapping = NULL,
 #'
 #' # with text labels
 #' ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-#'   geom_edges(color = "grey50") +
+#'   geom_edges(colour = "grey50") +
 #'   geom_nodelabel(aes(label = vertex.names)) +
 #'   theme_blank()
 #'
 #' # with text labels coloured according to degree centrality
 #' n %v% "degree" <- degree(n)
 #' ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-#'   geom_edges(color = "grey50") +
+#'   geom_edges(colour = "grey50") +
 #'   geom_nodelabel(aes(label = vertex.names, fill = degree)) +
 #'   scale_fill_gradient(low = "gold", high = "tomato") +
 #'   theme_blank()
@@ -236,10 +236,10 @@ geom_nodetext_repel <- function(mapping = NULL,
 #' # label only a subset of all nodes
 #' high_degree <- function(x) { x[ x$degree > median(x$degree), ] }
 #' ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-#'   geom_edges(color = "steelblue") +
-#'   geom_nodes(aes(size = degree), color = "steelblue") +
+#'   geom_edges(colour = "steelblue") +
+#'   geom_nodes(aes(size = degree), colour = "steelblue") +
 #'   geom_nodelabel(aes(label = vertex.names), data = high_degree,
-#'                  color = "white", fill = "tomato") +
+#'                  colour = "white", fill = "tomato") +
 #'   theme_blank()
 #' }
 #'
@@ -296,23 +296,23 @@ geom_nodelabel <- function(mapping = NULL, data = NULL,
 #' n <- network(flo, directed = FALSE)
 #'
 #' ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-#'   geom_edges(color = "steelblue") +
+#'   geom_edges(colour = "steelblue") +
 #'   geom_nodelabel_repel(aes(label = vertex.names),
 #'                       box.padding = unit(1, "lines")) +
-#'   geom_nodes(color = "steelblue", size = 3) +
+#'   geom_nodes(colour = "steelblue", size = 3) +
 #'   theme_blank()
 #'
 #' # label only a subset of all nodes
 #' n %v% "degree" <- degree(n)
 #' low_degree <- function(x) { x[ x$degree < median(x$degree), ] }
 #' ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-#'   geom_edges(color = "steelblue") +
+#'   geom_edges(colour = "steelblue") +
 #'   geom_nodelabel_repel(aes(label = vertex.names),
 #'                        box.padding = unit(1.5, "lines"),
 #'                        data = low_degree,
-#'                        segment.color = "tomato",
-#'                        color = "white", fill = "tomato") +
-#'   geom_nodes(aes(size = degree), color = "steelblue") +
+#'                        segment.colour = "tomato",
+#'                        colour = "white", fill = "tomato") +
+#'   geom_nodes(aes(size = degree), colour = "steelblue") +
 #'   theme_blank()
 #'
 #' }
@@ -326,7 +326,7 @@ geom_nodelabel_repel <- function(
   point.padding = unit(1e-6, "lines"),
   label.r = unit(0.15, "lines"),
   label.size = 0.25,
-  segment.color = "#666666",
+  segment.colour = "#666666",
   segment.size = 0.5,
   arrow = NULL,
   force = 1,
@@ -352,7 +352,7 @@ geom_nodelabel_repel <- function(
       point.padding  = point.padding,
       label.r = label.r,
       label.size = label.size,
-      segment.color = segment.color,
+      segment.colour = segment.colour,
       segment.size = segment.size,
       arrow = arrow,
       na.rm = na.rm,

--- a/man/geom_edges.Rd
+++ b/man/geom_edges.Rd
@@ -60,7 +60,7 @@ the default plot specification, e.g. \code{\link{borders}}.}
 
 \item{...}{other arguments passed on to \code{\link{layer}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
-\code{color = "red"} or \code{size = 3}. They may also be parameters
+\code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}
 }
 \description{
@@ -80,27 +80,27 @@ n <- network(rgraph(10, tprob = 0.2), directed = TRUE)
 
 # just edges
 ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-  geom_edges(size = 1, color = "steelblue") +
+  geom_edges(size = 1, colour = "steelblue") +
   theme_blank()
 
 # with nodes
 ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-  geom_edges(size = 1, color = "steelblue") +
-  geom_nodes(size = 3, color = "steelblue") +
+  geom_edges(size = 1, colour = "steelblue") +
+  geom_nodes(size = 3, colour = "steelblue") +
   theme_blank()
 
 # with arrows
 ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-  geom_edges(size = 1, color = "steelblue",
+  geom_edges(size = 1, colour = "steelblue",
              arrow = arrow(length = unit(0.5, "lines"), type = "closed")) +
-  geom_nodes(size = 3, color = "steelblue") +
+  geom_nodes(size = 3, colour = "steelblue") +
   theme_blank()
 
 # with curvature
 ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-  geom_edges(size = 1, color = "steelblue", curvature = 0.15,
+  geom_edges(size = 1, colour = "steelblue", curvature = 0.15,
              arrow = arrow(length = unit(0.5, "lines"), type = "closed")) +
-  geom_nodes(size = 3, color = "steelblue") +
+  geom_nodes(size = 3, colour = "steelblue") +
   theme_blank()
 
 # arbitrary categorical edge attribute
@@ -109,25 +109,25 @@ set.edge.attribute(n, "type", e)
 ggplot(n, aes(x, y, xend = xend, yend = yend)) +
   geom_edges(aes(linetype = type), size = 1, curvature = 0.15,
              arrow = arrow(length = unit(0.5, "lines"), type = "closed")) +
-  geom_nodes(size = 3, color = "steelblue") +
+  geom_nodes(size = 3, colour = "steelblue") +
   theme_blank()
 
 # arbitrary numeric edge attribute (signed network)
 e <- sample(-2:2, network.edgecount(n), replace = TRUE)
 set.edge.attribute(n, "weight", e)
 ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-  geom_edges(aes(color = weight), curvature = 0.15,
+  geom_edges(aes(colour = weight), curvature = 0.15,
              arrow = arrow(length = unit(0.5, "lines"), type = "closed")) +
-  geom_nodes(size = 3, color = "grey50") +
-  scale_color_gradient(low = "steelblue", high = "tomato") +
+  geom_nodes(size = 3, colour = "grey50") +
+  scale_colour_gradient(low = "steelblue", high = "tomato") +
   theme_blank()
 
 # draw only a subset of all edges
 positive_weight <- function(x) { x[ x$weight >= 0, ] }
 ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-  geom_edges(aes(color = weight), data = positive_weight) +
-  geom_nodes(size = 4, color = "grey50") +
-  scale_color_gradient(low = "gold", high = "tomato") +
+  geom_edges(aes(colour = weight), data = positive_weight) +
+  geom_nodes(size = 4, colour = "grey50") +
+  scale_colour_gradient(low = "gold", high = "tomato") +
   theme_blank()
 
 }

--- a/man/geom_edgetext.Rd
+++ b/man/geom_edgetext.Rd
@@ -45,7 +45,7 @@ displayed as described in ?plotmath}
 
 \item{...}{other arguments passed on to \code{\link{layer}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
-\code{color = "red"} or \code{size = 3}. They may also be parameters
+\code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}
 
 \item{nudge_x, nudge_y}{Horizontal and vertical adjustment to nudge labels by.
@@ -90,9 +90,9 @@ set.edge.attribute(n, "type", e)
 
 # with labelled edges
 ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-  geom_edges(aes(color = type)) +
-  geom_edgetext(aes(label = type, color = type)) +
-  geom_nodes(size = 4, color = "grey50") +
+  geom_edges(aes(colour = type)) +
+  geom_edgetext(aes(label = type, colour = type)) +
+  geom_nodes(size = 4, colour = "grey50") +
   theme_blank()
 
 # label only a subset of all edges with arbitrary symbol
@@ -100,7 +100,7 @@ edge_type <- function(x) { x[ x$type == "a", ] }
 ggplot(n, aes(x, y, xend = xend, yend = yend)) +
   geom_edges() +
   geom_edgetext(label = "=", data = edge_type) +
-  geom_nodes(size = 4, color = "grey50") +
+  geom_nodes(size = 4, colour = "grey50") +
   theme_blank()
 
 }

--- a/man/geom_edgetext_repel.Rd
+++ b/man/geom_edgetext_repel.Rd
@@ -8,14 +8,14 @@
 geom_edgetext_repel(mapping = NULL, data = NULL, parse = FALSE, ...,
   box.padding = unit(0.25, "lines"), label.padding = unit(0.25, "lines"),
   point.padding = unit(1e-06, "lines"), label.r = unit(0.15, "lines"),
-  label.size = 0.25, segment.color = "#666666", segment.size = 0.5,
+  label.size = 0.25, segment.colour = "#666666", segment.size = 0.5,
   arrow = NULL, force = 1, max.iter = 2000, nudge_x = 0, nudge_y = 0,
   na.rm = FALSE, show.legend = NA, inherit.aes = TRUE)
 
 geom_edgelabel_repel(mapping = NULL, data = NULL, parse = FALSE, ...,
   box.padding = unit(0.25, "lines"), label.padding = unit(0.25, "lines"),
   point.padding = unit(1e-06, "lines"), label.r = unit(0.15, "lines"),
-  label.size = 0.25, segment.color = "#666666", segment.size = 0.5,
+  label.size = 0.25, segment.colour = "#666666", segment.size = 0.5,
   arrow = NULL, force = 1, max.iter = 2000, nudge_x = 0, nudge_y = 0,
   na.rm = FALSE, show.legend = NA, inherit.aes = TRUE)
 }
@@ -101,17 +101,17 @@ set.edge.attribute(n, "day", e)
 ggplot(n, aes(x, y, xend = xend, yend = yend)) +
   geom_edges() +
   geom_edgetext_repel(aes(label = day), box.padding = unit(0.5, "lines")) +
-  geom_nodes(size = 4, color = "grey50") +
+  geom_nodes(size = 4, colour = "grey50") +
   theme_blank()
 
 # repulsive edge labels for only a subset of all edges
 edge_day <- function(x) { x[ x$day > 2, ] }
 ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-  geom_edges(aes(color = cut(day, (4:0)[ -3 ]))) +
+  geom_edges(aes(colour = cut(day, (4:0)[ -3 ]))) +
   geom_edgetext_repel(aes(label = paste("day", day),
-                      color = cut(day, (4:0)[ -3 ])), data = edge_day) +
-  geom_nodes(size = 4, color = "grey50") +
-  scale_color_manual("day", labels = c("old ties", "day 3", "day 4"),
+                      colour = cut(day, (4:0)[ -3 ])), data = edge_day) +
+  geom_nodes(size = 4, colour = "grey50") +
+  scale_colour_manual("day", labels = c("old ties", "day 3", "day 4"),
                      values = c("grey50", "gold", "tomato")) +
   theme_blank()
 

--- a/man/geom_nodes.Rd
+++ b/man/geom_nodes.Rd
@@ -44,7 +44,7 @@ the default plot specification, e.g. \code{\link{borders}}.}
 
 \item{...}{other arguments passed on to \code{\link{layer}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
-\code{color = "red"} or \code{size = 3}. They may also be parameters
+\code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}
 }
 \description{
@@ -59,28 +59,28 @@ n <- network(flo, directed = FALSE)
 
 # just nodes
 ggplot(n, aes(x, y)) +
-  geom_nodes(size = 3, shape = 21, color = "steelblue") +
+  geom_nodes(size = 3, shape = 21, colour = "steelblue") +
   theme_blank()
 
 # with edges
 ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-  geom_edges(color = "steelblue") +
-  geom_nodes(size = 3, shape = 21, color = "steelblue", fill = "white") +
+  geom_edges(colour = "steelblue") +
+  geom_nodes(size = 3, shape = 21, colour = "steelblue", fill = "white") +
   theme_blank()
 
 # with nodes sized according to degree centrality
 ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-  geom_edges(color = "steelblue") +
-  geom_nodes(size = degree(n), shape = 21, color = "steelblue", fill = "white") +
+  geom_edges(colour = "steelblue") +
+  geom_nodes(size = degree(n), shape = 21, colour = "steelblue", fill = "white") +
   theme_blank()
 
 # with nodes colored according to betweenness centrality
 
 n \%v\% "betweenness" <- betweenness(flo)
 ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-  geom_edges(color = "grey50") +
-  geom_nodes(aes(color = betweenness), size = 3) +
-  scale_color_gradient(low = "gold", high = "tomato") +
+  geom_edges(colour = "grey50") +
+  geom_nodes(aes(colour = betweenness), size = 3) +
+  scale_colour_gradient(low = "gold", high = "tomato") +
   theme_blank() +
   theme(legend.position = "bottom")
 

--- a/man/geom_nodetext.Rd
+++ b/man/geom_nodetext.Rd
@@ -39,7 +39,7 @@ a call to a position adjustment function.}
 
 \item{...}{other arguments passed on to \code{\link{layer}}. These are
 often aesthetics, used to set an aesthetic to a fixed value, like
-\code{color = "red"} or \code{size = 3}. They may also be parameters
+\code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}
 
 \item{parse}{If TRUE, the labels will be parsed into expressions and
@@ -87,14 +87,14 @@ ggplot(n, aes(x, y)) +
 
 # with nodes underneath
 ggplot(n, aes(x, y)) +
-  geom_nodes(color = "gold", size = 9) +
+  geom_nodes(colour = "gold", size = 9) +
   geom_nodetext(aes(label = vertex.names)) +
   theme_blank()
 
 # with nodes and edges
 ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-  geom_edges(color = "gold") +
-  geom_nodes(color = "gold", size = 9) +
+  geom_edges(colour = "gold") +
+  geom_nodes(colour = "gold", size = 9) +
   geom_nodetext(aes(label = vertex.names)) +
   theme_blank()
 
@@ -109,14 +109,14 @@ n <- network(flo, directed = FALSE)
 
 # with text labels
 ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-  geom_edges(color = "grey50") +
+  geom_edges(colour = "grey50") +
   geom_nodelabel(aes(label = vertex.names)) +
   theme_blank()
 
 # with text labels coloured according to degree centrality
 n \%v\% "degree" <- degree(n)
 ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-  geom_edges(color = "grey50") +
+  geom_edges(colour = "grey50") +
   geom_nodelabel(aes(label = vertex.names, fill = degree)) +
   scale_fill_gradient(low = "gold", high = "tomato") +
   theme_blank()
@@ -124,10 +124,10 @@ ggplot(n, aes(x, y, xend = xend, yend = yend)) +
 # label only a subset of all nodes
 high_degree <- function(x) { x[ x$degree > median(x$degree), ] }
 ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-  geom_edges(color = "steelblue") +
-  geom_nodes(aes(size = degree), color = "steelblue") +
+  geom_edges(colour = "steelblue") +
+  geom_nodes(aes(size = degree), colour = "steelblue") +
   geom_nodelabel(aes(label = vertex.names), data = high_degree,
-                 color = "white", fill = "tomato") +
+                 colour = "white", fill = "tomato") +
   theme_blank()
 }
 

--- a/man/geom_nodetext_repel.Rd
+++ b/man/geom_nodetext_repel.Rd
@@ -7,14 +7,14 @@
 \usage{
 geom_nodetext_repel(mapping = NULL, data = NULL, parse = FALSE, ...,
   box.padding = unit(0.25, "lines"), point.padding = unit(1e-06, "lines"),
-  segment.color = "#666666", segment.size = 0.5, arrow = NULL,
+  segment.colour = "#666666", segment.size = 0.5, arrow = NULL,
   force = 1, max.iter = 2000, nudge_x = 0, nudge_y = 0, na.rm = FALSE,
   show.legend = NA, inherit.aes = TRUE)
 
 geom_nodelabel_repel(mapping = NULL, data = NULL, parse = FALSE, ...,
   box.padding = unit(0.25, "lines"), label.padding = unit(0.25, "lines"),
   point.padding = unit(1e-06, "lines"), label.r = unit(0.15, "lines"),
-  label.size = 0.25, segment.color = "#666666", segment.size = 0.5,
+  label.size = 0.25, segment.colour = "#666666", segment.size = 0.5,
   arrow = NULL, force = 1, max.iter = 2000, nudge_x = 0, nudge_y = 0,
   na.rm = FALSE, show.legend = NA, inherit.aes = TRUE)
 }
@@ -92,10 +92,10 @@ if (require(network) && require(sna)) {
 
 n <- network(rgraph(10, tprob = 0.2), directed = FALSE)
 ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-  geom_edges(color = "steelblue") +
+  geom_edges(colour = "steelblue") +
   geom_nodetext_repel(aes(label = paste("node", vertex.names)),
                       box.padding = unit(1, "lines")) +
-  geom_nodes(color = "steelblue", size = 3) +
+  geom_nodes(colour = "steelblue", size = 3) +
   theme_blank()
 
 }
@@ -107,23 +107,23 @@ data(flo, package = "network")
 n <- network(flo, directed = FALSE)
 
 ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-  geom_edges(color = "steelblue") +
+  geom_edges(colour = "steelblue") +
   geom_nodelabel_repel(aes(label = vertex.names),
                       box.padding = unit(1, "lines")) +
-  geom_nodes(color = "steelblue", size = 3) +
+  geom_nodes(colour = "steelblue", size = 3) +
   theme_blank()
 
 # label only a subset of all nodes
 n \%v\% "degree" <- degree(n)
 low_degree <- function(x) { x[ x$degree < median(x$degree), ] }
 ggplot(n, aes(x, y, xend = xend, yend = yend)) +
-  geom_edges(color = "steelblue") +
+  geom_edges(colour = "steelblue") +
   geom_nodelabel_repel(aes(label = vertex.names),
                        box.padding = unit(1.5, "lines"),
                        data = low_degree,
-                       segment.color = "tomato",
-                       color = "white", fill = "tomato") +
-  geom_nodes(aes(size = degree), color = "steelblue") +
+                       segment.colour = "tomato",
+                       colour = "white", fill = "tomato") +
+  geom_nodes(aes(size = degree), colour = "steelblue") +
   theme_blank()
 
 }


### PR DESCRIPTION
Since both ggplot2 and ggrepel use "colour", a warning occures when using "segment.color".

Fixing an issue in fortify.network for nodes=2, in which case, the matrix/data.frame structure was dropped. Issue solved by using "drop" argument.

Fixing issue in fortify.network when no edges.