### PR TITLE
Small change to address the issue when your list of edges has only 1 …

### DIFF
--- a/R/fortify-network.R
+++ b/R/fortify-network.R
@@ -139,10 +139,12 @@ fortify.network <- function(model, data = NULL,
   edges = network::as.matrix.network.edgelist(x, attrname = weights)
 
   # edge list (if there are duplicated rows)
-  if (nrow(edges[, 1:2]) > nrow(unique(edges[, 1:2]))) {
+  if (nrow(edges) > 1) {
+    if (nrow(edges[, 1:2]) > nrow(unique(edges[, 1:2]))) {
     warning("duplicated edges detected")
+    }
   }
-
+  
   edges = data.frame(nodes[edges[, 1], 1:2], nodes[edges[, 2], 1:2])
   names(edges) = c("x", "y", "xend", "yend")
 


### PR DESCRIPTION
…entry

I just ran into an issue where the fortify was failing when the edge list of one row. I'm not sure this is the best way to handle the issue but I wanted to provide a possible solution. the  issue is that  `edges[, 1:2]` will return a vector instead of a data frame which will cause `nrow` to throw an error.