### PR TITLE
Fixes network layouts where x or y are constant

### DIFF
--- a/R/fortify-network.R
+++ b/R/fortify-network.R
@@ -126,8 +126,8 @@ fortify.network <- function(model, data = NULL,
   names(nodes) = c("x", "y")
 
   # rescale coordinates
-  nodes$x = scale(nodes$x, center = min(nodes$x), scale = diff(range(nodes$x)))
-  nodes$y = scale(nodes$y, center = min(nodes$y), scale = diff(range(nodes$y)))
+  nodes$x = scale2(nodes$x)
+  nodes$y = scale2(nodes$y)
 
   # import vertex attributes
   for (y in network::list.vertex.attributes(x)) {

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -35,3 +35,21 @@ theme_facet <- function(base_size = 12, base_family = "", ...) {
       ...
     )
 }
+
+#' A new scale function
+#'
+#' Appropriately handles the case for scaling if a column is constant
+#' @param xx The value to scale
+theme_blank <- function(base_size = 12, base_family = "", ...) {
+  ggplot2::theme_bw(base_size = base_size, base_family = base_family) +
+    ggplot2::theme(
+      axis.text = ggplot2::element_blank(),
+      axis.ticks = ggplot2::element_blank(),
+      axis.title = ggplot2::element_blank(),
+      legend.key = ggplot2::element_blank(),
+      panel.background = ggplot2::element_rect(fill = "white", colour = NA),
+      panel.border = ggplot2::element_blank(),
+      panel.grid = ggplot2::element_blank(),
+      ...
+    )
+}

--- a/R/utilities.R
+++ b/R/utilities.R
@@ -40,16 +40,12 @@ theme_facet <- function(base_size = 12, base_family = "", ...) {
 #'
 #' Appropriately handles the case for scaling if a column is constant
 #' @param xx The value to scale
-theme_blank <- function(base_size = 12, base_family = "", ...) {
-  ggplot2::theme_bw(base_size = base_size, base_family = base_family) +
-    ggplot2::theme(
-      axis.text = ggplot2::element_blank(),
-      axis.ticks = ggplot2::element_blank(),
-      axis.title = ggplot2::element_blank(),
-      legend.key = ggplot2::element_blank(),
-      panel.background = ggplot2::element_rect(fill = "white", colour = NA),
-      panel.border = ggplot2::element_blank(),
-      panel.grid = ggplot2::element_blank(),
-      ...
-    )
+scale2 <- function(xx){
+    s <- diff(range(xx))
+    if(s==0){
+      res <- rep(0.5, length.out=length(xx))
+    }else{
+      res <- scale(xx, center = min(xx), scale = s)
+    }
+    return(res)
 }


### PR DESCRIPTION
If we want to plot a network in a straight line such as 1 --> 2 --> 3 by passing in an xy layout matrix, ggnetwork breaks because the rescaling function used gives NaN. I added a simple scale2() function that deals with the special case where a column is constant by just setting all values in the column = 0.5.

See error example below:

```r
## Create network
edge.list <- matrix(c(1,2,2,3), ncol=2)
net <- network(edge.list, matrix.type='edgelist')

## Create x,y layout matrix:
xy.mat <- matrix(c(1,2,3,1,1,1), ncol=2)
colnames(xy.mat) <- c('x', 'y')

## Does not work
ggplot(net, layout=xy.mat, aes(x = x, y = y, xend = xend, yend = yend)) +
  geom_edges() + geom_nodes()
```

Problematic lines of code in ggnetwork:::fortify.network() :

```r
nodes$x = scale(nodes$x, center = min(nodes$x), scale = diff(range(nodes$x)))
nodes$y = scale(nodes$y, center = min(nodes$y), scale = diff(range(nodes$y)))
## >>> These return NA when nodes$x or nodes$y are a constant 
```

Simple fix: change the scale functions above to scale2(), defined here:

```r
scale2 <- function(xx){
    s <- diff(range(xx))
    if(s==0){
      res <- rep(0.5, length.out=length(xx))
    }else{
      res <- scale(xx, center = min(xx), scale = s)
    }
    return(res)
}
```
