### PR TITLE
Replace deprecated label.size with linewidth

### DIFF
--- a/R/geom-edges.R
+++ b/R/geom-edges.R
@@ -126,7 +126,7 @@ geom_edges <- function(
 #' All arguments to both \code{\link{geom_edgetext}} and
 #' \code{\link{geom_edgelabel}} are identical to those of
 #' \code{\link[ggplot2]{geom_label}}, with the only difference that the
-#' \code{label.size} argument defaults to \code{0} in order to avoid drawing a
+#' \code{linewidth} argument defaults to \code{0} in order to avoid drawing a
 #' border around the edge labels. The labels will be drawn at mid-edges.
 #' \code{\link[ggplot2]{geom_text}} and \code{\link[ggplot2]{geom_label}}
 #' produce strictly identical results.
@@ -171,7 +171,7 @@ geom_edgetext <- function(
   nudge_y = 0,
   label.padding = unit(0.25, "lines"),
   label.r = unit(0.15, "lines"),
-  label.size = 0,
+  linewidth = 0,
   na.rm = FALSE,
   show.legend = NA,
   inherit.aes = TRUE
@@ -196,7 +196,7 @@ geom_edgetext <- function(
       parse = parse,
       label.padding = label.padding,
       label.r = label.r,
-      label.size = label.size,
+      linewidth = linewidth,
       na.rm = na.rm,
       ...
     )
@@ -256,7 +256,7 @@ geom_edgetext_repel <- function(
   label.padding = unit(0.25, "lines"),
   point.padding = unit(1e-6, "lines"),
   label.r = unit(0.15, "lines"),
-  label.size = 0.25,
+  linewidth = 0.25,
   #segment.colour = "#666666",
   #segment.size = 0.5,
   arrow = NULL,
@@ -282,7 +282,7 @@ geom_edgetext_repel <- function(
       label.padding = label.padding,
       point.padding = point.padding,
       label.r = label.r,
-      label.size = label.size,
+      linewidth = linewidth,
       #segment.colour = segment.colour,
       #segment.size = segment.size,
       arrow = arrow,

--- a/R/geom-nodes.R
+++ b/R/geom-nodes.R
@@ -251,7 +251,7 @@ geom_nodelabel <- function(
   nudge_y = 0,
   label.padding = unit(0.25, "lines"),
   label.r = unit(0.15, "lines"),
-  label.size = 0.25,
+  linewidth = 0.25,
   na.rm = FALSE,
   show.legend = NA,
   inherit.aes = TRUE
@@ -275,7 +275,7 @@ geom_nodelabel <- function(
       parse = parse,
       label.padding = label.padding,
       label.r = label.r,
-      label.size = label.size,
+      linewidth = linewidth,
       na.rm = na.rm,
       ...
     )
@@ -328,7 +328,7 @@ geom_nodelabel_repel <- function(
   label.padding = unit(0.25, "lines"),
   point.padding = unit(1e-6, "lines"),
   label.r = unit(0.15, "lines"),
-  label.size = 0.25,
+  linewidth = 0.25,
   #segment.colour = "#666666",
   #segment.size = 0.5,
   arrow = NULL,
@@ -354,7 +354,7 @@ geom_nodelabel_repel <- function(
       label.padding = label.padding,
       point.padding = point.padding,
       label.r = label.r,
-      label.size = label.size,
+      linewidth = linewidth,
       #segment.colour = segment.colour,
       #segment.size = segment.size,
       arrow = arrow,

--- a/man/geom_edges.Rd
+++ b/man/geom_edges.Rd
@@ -74,12 +74,14 @@ a warning. If \code{TRUE}, missing values are silently removed.}
 \code{NA}, the default, includes if any aesthetics are mapped.
 \code{FALSE} never includes, and \code{TRUE} always includes.
 It can also be a named logical vector to finely select the aesthetics to
-display.}
+display. To include legend keys for all levels, even
+when no data exists, use \code{TRUE}.  If \code{NA}, all levels are shown in legend,
+but unobserved levels are omitted.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
-the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
+the default plot specification, e.g. \code{\link[ggplot2:annotation_borders]{annotation_borders()}}.}
 
 \item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}'s \code{params} argument. These
 arguments broadly fall into one of 4 categories below. Notably, further

--- a/man/geom_edgetext.Rd
+++ b/man/geom_edgetext.Rd
@@ -15,7 +15,7 @@ geom_edgetext(
   nudge_y = 0,
   label.padding = unit(0.25, "lines"),
   label.r = unit(0.15, "lines"),
-  label.size = 0,
+  linewidth = 0,
   na.rm = FALSE,
   show.legend = NA,
   inherit.aes = TRUE
@@ -31,7 +31,7 @@ geom_edgelabel(
   nudge_y = 0,
   label.padding = unit(0.25, "lines"),
   label.r = unit(0.15, "lines"),
-  label.size = 0,
+  linewidth = 0,
   na.rm = FALSE,
   show.legend = NA,
   inherit.aes = TRUE
@@ -58,13 +58,13 @@ the plot data. The return value must be a \code{data.frame}, and
 will be used as the layer data. A \code{function} can be created
 from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
-\item{position}{A position adjustment to use on the data for this layer.
-Cannot be jointy specified with \code{nudge_x} or \code{nudge_y}. This
+\item{position}{A position adjustment to use on the data for this layer. This
 can be used in various ways, including to prevent overplotting and
 improving the display. The \code{position} argument accepts the following:
 \itemize{
 \item The result of calling a position function, such as \code{position_jitter()}.
-\item A string nameing the position adjustment. To give the position as a
+This method allows for passing extra arguments to the position.
+\item A string naming the position adjustment. To give the position as a
 string, strip the function name of the \code{position_} prefix. For example,
 to use \code{position_jitter()}, give the position as \code{"jitter"}.
 \item For more information and other ways to specify the position, see the
@@ -102,15 +102,9 @@ lists which parameters it can accept.
 \link[ggplot2:draw_key]{key glyphs}, to change the display of the layer in the legend.
 }}
 
-\item{nudge_x, nudge_y}{Horizontal and vertical adjustment to nudge labels by.
-Useful for offsetting text from points, particularly on discrete scales.
-Cannot be jointly specified with \code{position}.}
-
 \item{label.padding}{Amount of padding around label. Defaults to 0.25 lines.}
 
 \item{label.r}{Radius of rounded corners. Defaults to 0.15 lines.}
-
-\item{label.size}{Size of label border, in mm.}
 
 \item{na.rm}{If \code{FALSE}, the default, missing values are removed with
 a warning. If \code{TRUE}, missing values are silently removed.}
@@ -119,18 +113,20 @@ a warning. If \code{TRUE}, missing values are silently removed.}
 \code{NA}, the default, includes if any aesthetics are mapped.
 \code{FALSE} never includes, and \code{TRUE} always includes.
 It can also be a named logical vector to finely select the aesthetics to
-display.}
+display. To include legend keys for all levels, even
+when no data exists, use \code{TRUE}.  If \code{NA}, all levels are shown in legend,
+but unobserved levels are omitted.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
-the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
+the default plot specification, e.g. \code{\link[ggplot2:annotation_borders]{annotation_borders()}}.}
 }
 \description{
 All arguments to both \code{\link{geom_edgetext}} and
 \code{\link{geom_edgelabel}} are identical to those of
 \code{\link[ggplot2]{geom_label}}, with the only difference that the
-\code{label.size} argument defaults to \code{0} in order to avoid drawing a
+\code{linewidth} argument defaults to \code{0} in order to avoid drawing a
 border around the edge labels. The labels will be drawn at mid-edges.
 \code{\link[ggplot2]{geom_text}} and \code{\link[ggplot2]{geom_label}}
 produce strictly identical results.

--- a/man/geom_edgetext_repel.Rd
+++ b/man/geom_edgetext_repel.Rd
@@ -14,7 +14,7 @@ geom_edgetext_repel(
   label.padding = unit(0.25, "lines"),
   point.padding = unit(1e-06, "lines"),
   label.r = unit(0.15, "lines"),
-  label.size = 0.25,
+  linewidth = 0.25,
   arrow = NULL,
   force = 1,
   max.iter = 10000,
@@ -34,7 +34,7 @@ geom_edgelabel_repel(
   label.padding = unit(0.25, "lines"),
   point.padding = unit(1e-06, "lines"),
   label.r = unit(0.15, "lines"),
-  label.size = 0.25,
+  linewidth = 0.25,
   arrow = NULL,
   force = 1,
   max.iter = 10000,
@@ -84,8 +84,6 @@ specified by passing \code{unit(x, "units")}).}
 \item{label.r}{Radius of rounded corners, as unit or number. Defaults
 to 0.15. (Default unit is lines, but other units can be specified by
 passing \code{unit(x, "units")}).}
-
-\item{label.size}{Size of label border, in mm.}
 
 \item{arrow}{specification for arrow heads, as created by \code{\link[grid]{arrow}}}
 

--- a/man/geom_nodes.Rd
+++ b/man/geom_nodes.Rd
@@ -55,12 +55,14 @@ a warning. If \code{TRUE}, missing values are silently removed.}
 \code{NA}, the default, includes if any aesthetics are mapped.
 \code{FALSE} never includes, and \code{TRUE} always includes.
 It can also be a named logical vector to finely select the aesthetics to
-display.}
+display. To include legend keys for all levels, even
+when no data exists, use \code{TRUE}.  If \code{NA}, all levels are shown in legend,
+but unobserved levels are omitted.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
-the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
+the default plot specification, e.g. \code{\link[ggplot2:annotation_borders]{annotation_borders()}}.}
 
 \item{...}{Other arguments passed on to \code{\link[ggplot2:layer]{layer()}}'s \code{params} argument. These
 arguments broadly fall into one of 4 categories below. Notably, further

--- a/man/geom_nodetext.Rd
+++ b/man/geom_nodetext.Rd
@@ -29,7 +29,7 @@ geom_nodelabel(
   nudge_y = 0,
   label.padding = unit(0.25, "lines"),
   label.r = unit(0.15, "lines"),
-  label.size = 0.25,
+  linewidth = 0.25,
   na.rm = FALSE,
   show.legend = NA,
   inherit.aes = TRUE
@@ -56,13 +56,13 @@ the plot data. The return value must be a \code{data.frame}, and
 will be used as the layer data. A \code{function} can be created
 from a \code{formula} (e.g. \code{~ head(.x, 10)}).}
 
-\item{position}{A position adjustment to use on the data for this layer.
-Cannot be jointy specified with \code{nudge_x} or \code{nudge_y}. This
+\item{position}{A position adjustment to use on the data for this layer. This
 can be used in various ways, including to prevent overplotting and
 improving the display. The \code{position} argument accepts the following:
 \itemize{
 \item The result of calling a position function, such as \code{position_jitter()}.
-\item A string nameing the position adjustment. To give the position as a
+This method allows for passing extra arguments to the position.
+\item A string naming the position adjustment. To give the position as a
 string, strip the function name of the \code{position_} prefix. For example,
 to use \code{position_jitter()}, give the position as \code{"jitter"}.
 \item For more information and other ways to specify the position, see the
@@ -100,10 +100,6 @@ lists which parameters it can accept.
 \item{parse}{If \code{TRUE}, the labels will be parsed into expressions and
 displayed as described in \code{?plotmath}.}
 
-\item{nudge_x, nudge_y}{Horizontal and vertical adjustment to nudge labels by.
-Useful for offsetting text from points, particularly on discrete scales.
-Cannot be jointly specified with \code{position}.}
-
 \item{check_overlap}{If \code{TRUE}, text that overlaps previous text in the
 same layer will not be plotted. \code{check_overlap} happens at draw time and in
 the order of the data. Therefore data should be arranged by the label
@@ -117,18 +113,18 @@ a warning. If \code{TRUE}, missing values are silently removed.}
 \code{NA}, the default, includes if any aesthetics are mapped.
 \code{FALSE} never includes, and \code{TRUE} always includes.
 It can also be a named logical vector to finely select the aesthetics to
-display.}
+display. To include legend keys for all levels, even
+when no data exists, use \code{TRUE}.  If \code{NA}, all levels are shown in legend,
+but unobserved levels are omitted.}
 
 \item{inherit.aes}{If \code{FALSE}, overrides the default aesthetics,
 rather than combining with them. This is most useful for helper functions
 that define both data and aesthetics and shouldn't inherit behaviour from
-the default plot specification, e.g. \code{\link[ggplot2:borders]{borders()}}.}
+the default plot specification, e.g. \code{\link[ggplot2:annotation_borders]{annotation_borders()}}.}
 
 \item{label.padding}{Amount of padding around label. Defaults to 0.25 lines.}
 
 \item{label.r}{Radius of rounded corners. Defaults to 0.15 lines.}
-
-\item{label.size}{Size of label border, in mm.}
 }
 \description{
 All arguments to these geoms are identical to those of

--- a/man/geom_nodetext_repel.Rd
+++ b/man/geom_nodetext_repel.Rd
@@ -31,7 +31,7 @@ geom_nodelabel_repel(
   label.padding = unit(0.25, "lines"),
   point.padding = unit(1e-06, "lines"),
   label.r = unit(0.15, "lines"),
-  label.size = 0.25,
+  linewidth = 0.25,
   arrow = NULL,
   force = 1,
   max.iter = 10000,
@@ -105,8 +105,6 @@ by passing \code{unit(x, "units")}).}
 \item{label.r}{Radius of rounded corners, as unit or number. Defaults
 to 0.15. (Default unit is lines, but other units can be specified by
 passing \code{unit(x, "units")}).}
-
-\item{label.size}{Size of label border, in mm.}
 }
 \description{
 All arguments to these geoms are identical to those of


### PR DESCRIPTION
Hi,

label.size got deprecated recently in igraph in favor to linewidth. This PR applies the change.

Example code:
```{r}
library(network)
library(sna)
library(ggnetwork)
data(flo, package = "network")
n <- network(flo, directed = FALSE)

# arbitrary categorical edge attribute
e <- sample(letters[ 1:4 ], network.edgecount(n), replace = TRUE)
set.edge.attribute(n, "type", e)

# with labelled edges
ggplot(n, aes(x, y, xend = xend, yend = yend)) +
  geom_edges(aes(colour = type)) +
  geom_edgetext(aes(label = type, colour = type)) +
  geom_nodes(size = 4, colour = "grey50") +
  theme_blank()
```

The last command results in a warning:
```
Warning message:
In geom_edgetext(aes(label = type, colour = type)) :
  Ignoring unknown parameters: `label.size`
```


